### PR TITLE
Upgrading to the latest version of the deploy plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,11 @@
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
It is in order to fix the Unauthorized 401 error for deploying snapshots