### PR TITLE
Change dependency of ugandaemrsync module to be provided in order to avoid ugandaemrreports to bundle it as a jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>ugandaemrsync-api</artifactId>
                 <version>${ugandaemrsyncVersion}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
https://app.asana.com/0/1133167201254915/1175654384884337
Change dependency of ugandaemrsync module to be provided in order to avoid ugandaemrreports to bundle it as a jar